### PR TITLE
feat: audit appending automation

### DIFF
--- a/js/append-audit.js
+++ b/js/append-audit.js
@@ -1,0 +1,108 @@
+const parseArgs = require('minimist');
+const chalk = require('chalk');
+const fs = require('fs');
+
+const args = parseArgs(process.argv.slice(2), {
+  string: [
+    'i',
+    'a',
+    'f'
+  ],
+  alias: {
+    report: 'i',
+    audit: 'a',
+    fingerprints: 'f'
+  }
+});
+
+if (checkArgs(args)) {
+  main(args);
+}
+
+function main(args) {
+
+  checkArgs(args);
+
+  const fingerprints = Array.isArray(args.fingerprints) ? args.fingerprints : [args.fingerprints];
+
+  info(`checking for fingerprints: ${JSON.stringify(fingerprints)}`);
+
+  info(`reading: ${args.report}`);
+  const jsonReport = JSON.parse(fs.readFileSync(args.report));
+
+  info(`analysing: ${args.report}`);
+  const auditInfo = {};
+  const auditItems = {};
+  jsonReport.forEach(item => {
+    fingerprints.forEach(fingerprint => {
+      if (item.fingerprint.startsWith(fingerprint)) {
+        auditItems[item.fingerprint] = "ignore";
+
+        if (auditInfo[fingerprint] === undefined) {
+          auditInfo[fingerprint] = 1;
+        } else {
+          auditInfo[fingerprint]++;
+        }
+      }
+    });
+  });
+
+  info('Times found:');
+  for (let fingerprint in auditInfo) {
+    info(`\t${fingerprint}: ${auditInfo[fingerprint]}`);
+  }
+
+  info(`reading: ${args.audit}`);
+  let fullAudit = fs.readFileSync(args.audit);
+
+  if (fullAudit.length === 0) {
+    fullAudit = {};
+  } else {
+    fullAudit = JSON.parse(fullAudit);
+  }
+  const concatenated = Object.assign(fullAudit, auditItems);
+
+  info(`writing to: ${args.audit}`);
+  fs.writeFileSync(args.audit, JSON.stringify(concatenated, null, 2));
+
+  let sep = " ";
+  let text = "Added audit info for";
+  for (let fingerprint in auditInfo) {
+    text = text + sep + fingerprint;
+    sep = ", "
+  }
+  success(text)
+}
+
+function checkArgs(args) {
+  let success = true;
+
+  if (!args.fingerprints) {
+    error(`at least one fingerprint is required (-f)`);
+    success = false;
+  }
+
+  if (!args.report) {
+    error(`a report file is required (-i)`);
+    success = false;
+  }
+
+  if (!args.audit) {
+    error(`an audit file is required to append to (-a)`)
+    success = false;
+  }
+
+  return success;
+}
+
+function info(data) {
+  console.log(chalk.white(data));
+}
+
+function error(data) {
+  console.log(chalk.bold.red(data));
+}
+
+function success(data) {
+  console.log(chalk.green(data));
+}

--- a/js/append-audit.js
+++ b/js/append-audit.js
@@ -20,17 +20,14 @@ if (checkArgs(args)) {
 }
 
 function main(args) {
-
-  checkArgs(args);
-
   const fingerprints = getFingerprints(args.fingerprints);
 
-  info(`checking for fingerprints: ${JSON.stringify(fingerprints)}`);
+  info(`checking for fingerprints: ${chalk.bold(fingerprints.join(', '))}\n`);
 
-  info(`reading: ${args.report}`);
+  info(`reading: ${chalk.bold(args.report)}`);
   const jsonReport = JSON.parse(fs.readFileSync(args.report));
 
-  info(`analysing: ${args.report}`);
+  info(`analysing...`);
   const auditInfo = {};
   const auditItems = {};
   jsonReport.forEach(item => {
@@ -47,15 +44,17 @@ function main(args) {
     });
   });
 
-  info('Times found:');
+  let text = 'Times found:\n';
   for (let fingerprint in auditInfo) {
-    info(`\t${fingerprint}: ${auditInfo[fingerprint]}`);
+    text += `  ${fingerprint}: ${auditInfo[fingerprint]}\n`;
   }
+
+  info(text)
 
   let fullAudit = [];
 
   if (fs.existsSync(args.audit)) {
-    info(`reading: ${args.audit}`);
+    info(`reading: ${chalk.bold(args.audit)}`);
     fullAudit = fs.readFileSync(args.audit);
   }
 
@@ -67,11 +66,10 @@ function main(args) {
 
   const concatenated = Object.assign(fullAudit, auditItems);
 
-  info(`writing to: ${args.audit}`);
+  info(`writing to: ${chalk.bold(args.audit)}\n`);
   fs.writeFileSync(args.audit, JSON.stringify(concatenated, null, 2));
 
-  let text = 'Added audit info for fingerprints: ' + Object.keys(auditInfo).join(', ');
-  success(text);
+  success(`Added audit info for fingerprints: ${chalk.bold(Object.keys(auditInfo).join(', '))}`);
 }
 
 function checkArgs(args) {
@@ -100,7 +98,6 @@ function checkArgs(args) {
   let fingerprints = args.fingerprints;
   fingerprints = removeEmptyFingerprints(fingerprints);
 
-  // now covers both 1 and multiple inputs
   if (fingerprints.length === 0) {
     error('provide at least one fingerprint');
     success = false;
@@ -111,7 +108,7 @@ function checkArgs(args) {
 
 function getFingerprints(fingerprints) {
   let altered = removeEmptyFingerprints(fingerprints);
-  altered = Array.isArray(altered) ? altered : [altered];
+  altered = Array.isArray(altered) ? altered : altered.split(',');
   return altered.filter((item, i) => altered.indexOf(item) === i);
 }
 

--- a/js/append-audit.js
+++ b/js/append-audit.js
@@ -66,7 +66,7 @@ function main(args) {
 
   const concatenated = Object.assign(fullAudit, auditItems);
 
-  info(`writing to: ${chalk.bold(args.audit)}\n`);
+  info(`writing: ${chalk.bold(args.audit)}\n`);
   fs.writeFileSync(args.audit, JSON.stringify(concatenated, null, 2));
 
   success(`Added audit info for fingerprints: ${chalk.bold(Object.keys(auditInfo).join(', '))}`);

--- a/js/package.json
+++ b/js/package.json
@@ -6,7 +6,12 @@
     "lodash": "^4.17.15"
   },
   "scripts": {
-    "ccd-dev-to-markup": "node ccd-def-to-markup"
+    "ccd-dev-to-markup": "node ccd-def-to-markup",
+    "audit": "node append-audit"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "chalk": "^4.1.0",
+    "minimist": "^1.2.5"
+  }
 }

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -2,3 +2,57 @@
 # yarn lockfile v1
 
 
+"@types/color-name@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
+  integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+
+ansi-styles@^4.1.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
+  integrity sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==
+  dependencies:
+    "@types/color-name" "^1.1.1"
+    color-convert "^2.0.1"
+
+chalk@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
+  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+has-flag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
+lodash@^4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+minimist@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
+supports-color@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
+  integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
+  dependencies:
+    has-flag "^4.0.0"


### PR DESCRIPTION
Made a script to pull and append fingerprints to the audit.json as it was becoming tedious.

**Usage**
```bash
yarn run audit -- -i path/to/report.json -a path/to/audit.json -f FINGERPRINT_1,FINGERPRINT_2... [-f ANOTHER_FINGERPRINT]
```
The full fingerprint isn't required just something to uniquely identify it (normally the fingerprint code)

**Expected report format**
```json
[
  {
    "fingerprint": "FINGERPRINT"
  }
]
```
**Expected audit format:**
```json
{
  "FINGERPRINT": "ignore"
}
```